### PR TITLE
Allow usage of Ansible module group defaults - for Ansible 2.12+

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,8 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: ">=2.9.10"
+action_groups:
+  netapp_azure:
+    - azure_rm_netapp_account
+    - azure_rm_netapp_capacity_pool
+    - azure_rm_netapp_snapshot
+    - azure_rm_netapp_volume


### PR DESCRIPTION
##### SUMMARY
Allow usage of Ansible module group defaults

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html

##### ADDITIONAL INFORMATION
Allows usage of module defaults like:
```
- hosts: localhost
  connection: local
  gather_facts: false
  collections:
    - netapp.azure
  module_defaults:
    group/netapp.ontap.netapp_azure:
       # common options goes here
```